### PR TITLE
SourceClear: fixes for vulnerable libraries

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,8 +10,8 @@
  
   <!-- Component Version Properties -->
   <properties>
-    <spring.version>4.3.11.RELEASE</spring.version>
-    <fileupload.version>1.3.2</fileupload.version>
+    <spring.version>4.3.15.RELEASE</spring.version>
+    <fileupload.version>1.3.3</fileupload.version>
   </properties>
   
   <!-- Dependencies begin here -->
@@ -90,7 +90,7 @@
     <dependency>
       <groupId>mysql</groupId>
       <artifactId>mysql-connector-java</artifactId>
-      <version>5.1.35</version>
+      <version>8.0.16</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
This pull request was generated by SourceClear to upgrade the following vulnerable libraries:

| Type | Library | From | To | Breaking |
| --- | --- | --- | --- | --- |
| MAVEN | `org.springframework:spring-web` | 4.3.11.RELEASE | 4.3.29.RELEASE | No |
| MAVEN | `org.springframework:spring-core` | 4.3.11.RELEASE | 4.3.15.RELEASE | No |
| MAVEN | `commons-fileupload:commons-fileupload` | 1.3.2 | 1.3.3 | No |
| MAVEN | `org.springframework:spring-webmvc` | 4.3.11.RELEASE | 4.3.20.RELEASE | No |
| MAVEN | `mysql:mysql-connector-java` | 5.1.35 | 8.0.16 | No |

Note that we only upgrade libraries which have versions without any known vulnerabilities. For more information, please see the corresponding [SourceClear report](https://sca.analysiscenter.veracode.com/teams/zQQSPgE/scans/25621601).

The **Breaking** column states the likelihood that updating to the recommended library version will cause breaking changes in your code. Please verify that the changes here won't cause issues with your project before merging.

To learn more about this feature, please visit our [Help Center](https://help.veracode.com/reader/hHHR3gv0wYc2WbCclECf_A/root) for documentation.

Note: this pull request was generated because you or someone else with access to this repository granted SourceClear access to submit pull requests.
<!-- srcclr-pr-id-62cb23d872c99a89d23000d311052c4f0ad59a73d8026ba8be1fd75ef52e8144 -->
